### PR TITLE
fix: restore UX after Tailwind 4 migration

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -14,6 +14,9 @@
 }
 
 @layer base {
+  *, ::before, ::after {
+    border-color: var(--color-gray-200);
+  }
   body {
     color: var(--foreground);
     background: var(--background);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,10 +13,12 @@
   }
 }
 
-body {
-  color: var(--foreground);
-  background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
+@layer base {
+  body {
+    color: var(--foreground);
+    background: var(--background);
+    font-family: Arial, Helvetica, sans-serif;
+  }
 }
 
 @media (max-width: 639px) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -103,8 +103,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         </header>
         <main className="max-w-7xl mx-auto p-4">
           <div className="flex flex-col lg:flex-row gap-8">
-            <aside className="w-full lg:w-64 shrink-0 order-2 lg:order-1" aria-label="Site navigation">
-              <nav className="bg-white p-6 rounded-lg shadow sticky top-4">
+            <aside className="w-full lg:w-64 shrink-0 order-2 lg:order-1 lg:sticky lg:top-4 lg:self-start" aria-label="Site navigation">
+              <nav className="bg-white p-6 rounded-lg shadow">
                 <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wider mb-4">
                   Navigate
                 </h2>


### PR DESCRIPTION
## Summary

Three TW3→TW4 behavioral regressions fixed. All stem from TW4's shift to CSS cascade layers and changed preflight defaults.

- **Background colors gone on all pages**: TW4 uses `@layer utilities` for utility classes. Unlayered CSS rules (like `body { background: var(--background) }` in `globals.css`) always win over layered ones, so the body background was overriding every `bg-*` utility class site-wide. Wrapped body styles in `@layer base` to restore correct cascade order.

- **Left rail not floating as a unit**: Moved `sticky top-4` from the inner `<nav>` to the `<aside>` wrapper and added `self-start` (required for `sticky` to work inside a flex container). Both Navigate and Recent Posts cards now float together.

- **Dividers rendering black**: TW3's preflight set a global default border color of `gray-200`. TW4 changed that default to `currentColor` (= text color), making all unstyled `border-*` elements appear black. Restored TW3 behavior via `@layer base { *, ::before, ::after { border-color: var(--color-gray-200) } }`.

## Test plan

- [ ] Visit home page — `bg-gray-100` body background is light gray, not white
- [ ] Visit blog listing — dividers between posts are faint gray, not black
- [ ] Visit Recent Posts in sidebar — `<hr>` divider is faint gray
- [ ] Scroll a long blog post — both left-rail cards (Navigate + Recent Posts) stick to the top together
- [ ] Footer `bg-gray-800` dark background renders correctly
- [ ] `npm run lint`, `npm test`, `npm run build` all pass

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)